### PR TITLE
Turning on relative asset paths in config.rb to fix mixing style assets....

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -63,7 +63,7 @@ configure :build do
   # activate :asset_hash
 
   # Use relative URLs
-  # activate :relative_assets
+  activate :relative_assets
 
   # Or use a different image path
   # set :http_prefix, "/Content/images/"


### PR DESCRIPTION
... This fixes #6.

Stylesheets are working with Middleman server locally, but being built with document root-relative URLs for the assets. When I turned on relative assets paths in config.rb, that fixed the asset paths in my local build directory, and it should fix it when you merge that change and re-build the GitHub Pages.
