### PR TITLE
Adds a new layout for pages called page that introduces an 8 column left...

### DIFF
--- a/source/about-us.html.erb
+++ b/source/about-us.html.erb
@@ -1,118 +1,80 @@
 ---
-title: About Us
+title: About | Code for Charlotte
+description:
+keywords:
+author:
+layout: page
 ---
-
-<div class="jumbotron">
-  <div class="container">
-    <div class="row">
-      <div class="text-left col-xs-12 col-sm-12 col-md-12 col-lg-12">
-        <h1>
-          About Us
-        </h1> <span class="second-sm">Our Mission and Team</span>
-      </div>
-
-    </div>
-
-  </div>
-</div>
-  </section>
-  <section class="features-section">
-<div class="container">
-  <div class="row">
-    <div class="col-xs-12 col-sm-8 col-md-8 col-lg-8">
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Who We Are
-          </h3>
-        </div>
-        <div class="panel-body">
-          <p>
-          Code for Charlotte is a <a href="http://codeforamerica.org/brigade/">brigade</a> of the national non-profit 
-          <a href="http://codeforamerica.org/">Code for America</a>.  Both organizations are dedicated to raising awareness
-          and demonstrating the value of <strong>open data</strong>, <strong>open source</strong>, and
-          <strong>open government</strong>.
-          </p>
-          <p>The City of Charlotte was one of ten cities selected for a <a href="http://www.codeforamerica.org/blog/2013/10/15/2014fellowship_launch/">2014 Fellowship</a>,
-          an extremely selective program that pairs technologists with governments across the country.  One of the selection criteria for the 
-          fellowship is citizen engagement around these values-- usually in the form of a brigade.  So when the fellowship was awarded,
-          we sprung to life!  Our first meeting was in January on 2014, and we've grown to over 200 civic hackers since.  We are one of the fastest
-          growing brigades in history, and already one of the largest overall.</p>
-          </p> 
-        </div>
-      </div>
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Our Mission
-          </h3>
-        </div>
-        <div class="panel-body">
-          <p>
-          Through its volunteer corps, Code For Charlotte represents an innovative, knowledgable technical resource for the City.
-          As technology becomes more vital in every governmental and administrative role, the demand for IT services is increasing faster than the City government can hire qualified employees.
-          IT projects are challenging in any environment, and government IT has even tighter constraints.
-          All citizens benefit from better technology, via expanded or improved service levels.
-          </p>
-          <p>Code for Charlotte's goals are the following:
-          <ul>
-            <li>Help the City achieve better outcomes from its IT budget.</li>
-            <li>Build a platform where City employees and engaged citizens can find each other to develop projects.</li>
-            <li>Incubate civic startups capable of serving the needs of the City and other governments.</li>
-            <li>Guide policy discussions at the local level regarding technology issues.</li>
-          </ul>
-          </p><hr />
-          <p>
-          <a href="/new-members.html" class="btn btn-lg btn-block btn-success">Get Involved</a>
-          </p>
-
-        </div>
-      </div>
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Our Team
-          </h3>
-        </div>
-        <div class="panel-body">
-          <p>
-
-          </p>
-          <p>
-          <dl>
-            <dt>Twyla McDermott</dt>
-            <dd>Twyla is in the City's Technology & Innovation department, and she is our primary contact with the City.</dd>
-            <dt>Jim Van Fleet</dt>
-            <dd>Brigade co-captain.  He owns a software consultancy, and is a leader in the entrepreneurship community in Charlotte.</dd>
-            <dt>Jill Bjers</dt>
-            <dd>Brigade co-captain.  She leads government outreach and our events calendar.</dd>
-          </dl>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-sm-4 col-md-4 col-lg-4 col-xs-12">
-
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Reference
-          </h3>
-        </div>
-        <div class="panel-body">
-          <ul>
-            <li><a href="http://codeforamerica.org/">Code for America</a></li>
-          </ul>
-        </div>
-      </div>
- 
-      <img class="img-responsive img-rounded" src="images/one.jpg" alt="" />
-
-      <p class="text-center custom-paragr lead">
-      The Charlotte fellows conferring with <strong>Councilman Greg Phipps</strong>.  Code for Charlotte
-      has ignited conversations across all levels of city and county government.
-      </p>
-    </div>
-  </div><hr />
-</div>
+<% content_for :jumbotron do %>
+<%= partial(:'partials/jumbotron', :locals => {:headline => 'About Us', :subheadline => 'Our Mission and Team' }) %>
+<% end %>
+          <div class="panel panel-default custom-panel">
+            <div class="panel-heading">
+              <h3>
+                Who We Are
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p>
+                Code for Charlotte is a <a href="http://codeforamerica.org/brigade/">brigade</a> of the national non-profit
+                <a href="http://codeforamerica.org/">Code for America</a>.  Both organizations are dedicated to raising awareness
+                and demonstrating the value of <strong>open data</strong>, <strong>open source</strong>, and
+                <strong>open government</strong>.
+              </p>
+              <p>
+                The City of Charlotte was one of ten cities selected for a <a href="http://www.codeforamerica.org/blog/2013/10/15/2014fellowship_launch/">2014 Fellowship</a>,
+                an extremely selective program that pairs technologists with governments across the country.  One of the selection criteria for the
+                fellowship is citizen engagement around these values-- usually in the form of a brigade.  So when the fellowship was awarded,
+                we sprung to life!  Our first meeting was in January on 2014, and we've grown to over 200 civic hackers since.  We are one of the fastest
+                growing brigades in history, and already one of the largest overall.</p>
+              </p>
+            </div>
+          </div>
+          <div class="panel panel-default custom-panel">
+            <div class="panel-heading">
+              <h3>
+                Our Mission
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p>
+              Through its volunteer corps, Code For Charlotte represents an innovative, knowledgable technical resource for the City.
+              As technology becomes more vital in every governmental and administrative role, the demand for IT services is increasing faster than the City government can hire qualified employees.
+              IT projects are challenging in any environment, and government IT has even tighter constraints.
+              All citizens benefit from better technology, via expanded or improved service levels.
+              </p>
+              <p>Code for Charlotte's goals are the following:
+              <ul>
+                <li>Help the City achieve better outcomes from its IT budget.</li>
+                <li>Build a platform where City employees and engaged citizens can find each other to develop projects.</li>
+                <li>Incubate civic startups capable of serving the needs of the City and other governments.</li>
+                <li>Guide policy discussions at the local level regarding technology issues.</li>
+              </ul>
+              </p><hr />
+              <p>
+              <a href="/new-members.html" class="btn btn-lg btn-block btn-success">Get Involved</a>
+              </p>
+            </div>
+          </div>
+          <div class="panel panel-default custom-panel">
+            <div class="panel-heading">
+              <h3>
+                Our Team
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p>
+                <dl>
+                  <dt>Twyla McDermott</dt>
+                  <dd>Twyla is in the City's Technology & Innovation department, and she is our primary contact with the City.</dd>
+                  <dt>Jim Van Fleet</dt>
+                  <dd>Brigade co-captain.  He owns a software consultancy, and is a leader in the entrepreneurship community in Charlotte.</dd>
+                  <dt>Jill Bjers</dt>
+                  <dd>Brigade co-captain.  She leads government outreach and our events calendar.</dd>
+                </dl>
+              </p>
+            </div>
+          </div>
+<% content_for :sidebar do %>
+<%= partial(:'partials/sidebar') %>
+<% end %>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,181 +1,178 @@
 ---
 title: Welcome to Code for Charlotte
+description:
+keywords:
+author:
 ---
-
-<div class="jumbotron">
-  <div class="container">
-    <div class="row">
-      <div class="text-left col-xs-12 col-sm-12 col-md-6 col-lg-6 text-right">
-        <h1>
-          CLT
-        </h1> <span class="second-sm">Our City</span>
-      </div>
-
-
-      <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6 custom-left">
-        <h2>
-          Open Data, Open Source
-        </h2>
-
-        <ul class="list-unstyled">
-          <li>
-          <i class="icon-ok-sign"></i> Your voice
-          </li>
-          <li>
-          <i class="icon-ok-sign"></i> Your ideas
-          </li>
-          <li>
-          <i class="icon-ok-sign"></i> Your choice
-          </li>
-          <li>
-          <i class="icon-ok-sign"></i> Your action
-          </li>
-
-        </ul>
-
+<% content_for :jumbotron do %>
+  <section>
+    <div class="jumbotron">
+      <div class="container">
         <div class="row">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-            <a href="/about-us.html" class="btn btn-default btn-lg btn-custom"><i class="icon-play-sign"></i>Learn More</a>
+          <div class="col-xs-12 col-md-6 text-right ">
+            <h1>
+              CLT
+            </h1>
+            <span class="second-sm">Our City</span>
+          </div>
+          <div class="col-xs-12 col-sm-6 custom-left">
+            <h2>
+              Open Data, Open Source
+            </h2>
+            <ul class="list-unstyled">
+              <li>
+                <i class="icon-ok-sign"></i> Your voice
+              </li>
+              <li>
+                <i class="icon-ok-sign"></i> Your ideas
+              </li>
+              <li>
+                <i class="icon-ok-sign"></i> Your choice
+              </li>
+              <li>
+                <i class="icon-ok-sign"></i> Your action
+              </li>
+            </ul>
+            <div class="row">
+              <div class="col-xs-12">
+                <a href="/about-us.html" class="btn btn-default btn-lg btn-custom">
+                  <i class="icon-play-sign"></i>
+                  Learn More
+                </a>
+              </div>
+            </div>
           </div>
         </div>
-
       </div>
-
     </div>
-
-  </div>
-</div>
   </section>
+<% end %>
   <section class="features-section">
-<div class="container">
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-      <div class="page-header text-center">
-        <h1>
-          Check out our awesome initiatives
-        </h1>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Fellowship
-          </h3>
-        </div>
-        <div class="panel-body">
-          <p class="text-center">
-          <i class="icon-rss icon-4x"></i>
-          </p>
-          <p>
-          The Charlotte fellows have been working on a prototype to connect
-          people with what's happening in their neighborhood.  You can
-          stay connected with them on their Tumblr.
-          </p><hr />
-          <p>
-          <a href="http://team-charlotte.tumblr.com" class="btn btn-lg btn-block btn-success">Follow the Fellows</a>
-          </p>
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12">
+          <div class="page-header text-center">
+            <h1>
+              Check out our awesome initiatives
+            </h1>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Our Brigade
-          </h3>
+      <div class="row">
+        <div class="col-xs-12 col-sm-4">
+          <div class="panel panel-default custom-panel">
+            <div class="panel-heading">
+              <h3>
+                Fellowship
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p class="text-center">
+                <i class="icon-rss icon-4x"></i>
+              </p>
+              <p>
+                The Charlotte fellows have been working on a prototype to connect
+                people with what's happening in their neighborhood.  You can
+                stay connected with them on their Tumblr.
+              </p>
+              <hr />
+              <p>
+                <%= link_to 'Follow the Fellows', 'http://team-charlotte.tumblr.com', {:class => 'btn btn-lg btn-block btn-success'} %>
+              </p>
+            </div>
+          </div>
         </div>
-        <div class="panel-body">
-          <p class="text-center">
-          <i class="icon-keyboard icon-4x"></i>
+        <div class="col-xs-12 col-sm-4">
+          <div class="panel panel-default custom-panel">
+            <div class="panel-heading">
+              <h3>
+                Our Brigade
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p class="text-center">
+                <i class="icon-keyboard icon-4x"></i>
+              </p>
+              <p class="lead text-center">
+                Help represent Code for Charlotte in uptown on June 17th!  The City's technology summit and Charlotte Data Day have both invited us to have a presence at their events.
+              </p>
+              <hr />
+              <p>
+                <%= link_to 'Volunteer', 'http://www.meetup.com/Code-For-Charlotte/', {:class => 'btn btn-lg btn-block btn-success'} %>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+          <div class="panel panel-default custom-panel">
+            <div class="panel-heading">
+              <h3>
+                Events
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p class="text-center">
+                <i class="icon-beer icon-4x"></i>
+              </p>
+              <p>
+                Our next hackathon will be the June 23, the fourth Monday in June.  We will be putting more structure in place regarding how to contribute.
+              </p>
+              <hr />
+              <p>
+                <%= link_to 'RSVP Today', 'http://www.meetup.com/Code-For-Charlotte/events/168731192/', {:class => 'btn btn-lg btn-block btn-success'} %>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <hr />
+      <div class="row">
+        <div class="col-xs-12 col-sm-4 col-sm-offset-4 col-lg-6 col-lg-offset-3">
+          <form action="http://itsbspoke.us2.list-manage.com/subscribe/post?u=8b4656bd4a093a3bcabfda08a&amp;id=4f80c66e83" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+            <div class="input-group">
+             <input type="email" class="form-control input-lg" name="EMAIL" id="mce-EMAIL"/>
+               <span class="input-group-btn">
+                 <button class="btn btn-primary btn-lg" type="submit" name="subscribe" id="mc-embedded-subscribe" >
+                   SUBSCRIBE!
+                 </button>
+               </span>
+            </div>
+            <div style="position: absolute; left: -5000px;">
+              <input type="text" name="b_8b4656bd4a093a3bcabfda08a_4f80c66e83" tabindex="-1" value="">
+            </div>
+          </form>
+        </div>
+      </div>
+      <hr />
+      <div class="row">
+        <div class="col-xs-12">
+          <div class="page-header text-center">
+            <h3>
+              Code For Charlotte In Action
+            </h3>
+          </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+          <img class="img-responsive img-rounded" src="images/one.jpg" alt="" />
+          <p class="text-center custom-paragr lead">
+            The Charlotte fellows conferring with <strong>Councilman Greg Phipps</strong>.  Code for Charlotte
+            has ignited conversations across all levels of city and county government.
           </p>
-          <p class="lead text-center">
-          Help represent Code for Charlotte in uptown on June 17th!  The City's technology summit and Charlotte Data Day have both invited us to have a presence at their events.
-          </p><hr />
-          <p>
-          <a href="http://www.meetup.com/Code-For-Charlotte/"
-             class="btn btn-lg btn-block btn-success">Volunteer</a>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+          <img class="img-responsive img-rounded" src="images/two.jpg" alt="" />
+          <p class="text-center custom-paragr lead">
+            <strong>Twyla McDermott</strong> from the City's Innovation &amp; Technology department, has
+            been Code for Charlotte's primary contact inside City government.  Thanks, Twyla!
+          </p>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+          <img class="img-responsive img-rounded" src="images/three.jpg" alt="" />
+          <p class="text-center custom-paragr lead">
+            Code For Charlotte has many opportunities to get engaged in person.  Check
+            <a href="http://www.meetup.com/Code-For-Charlotte">our Meetup</a> for more
+            information.
           </p>
         </div>
       </div>
     </div>
-    <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Events
-          </h3>
-        </div>
-        <div class="panel-body">
-          <p class="text-center">
-          <i class="icon-beer icon-4x"></i>
-          </p>
-          <p>
-          Our next hackathon will be the June 23, the fourth Monday in June.  We'll be putting more structure in place regarding how to contribute.
-          </p><hr />
-          <p>
-          <a href="http://www.meetup.com/Code-For-Charlotte/events/168731192/"
-             class="btn btn-lg btn-block btn-success">RSVP Today</a>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div><hr />
-  <div class="row">
-    <div class="col-xs-12 col-sm-4 col-md-4 col-lg-3">
-    </div>
-    <div class="col-xs-12 col-sm-4 col-md-4  col-lg-6">
-      <form action="http://itsbspoke.us2.list-manage.com/subscribe/post?u=8b4656bd4a093a3bcabfda08a&amp;id=4f80c66e83" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-      <div class="input-group">
-       <input type="email" class="form-control input-lg" name="EMAIL" id="mce-EMAIL"/>
-         <span class="input-group-btn">
-           <button class="btn btn-primary btn-lg" type="submit" name="subscribe" id="mc-embedded-subscribe" >
-             SUBSCRIBE!
-           </button>
-         </span>
-      </div>
-      <div style="position: absolute; left: -5000px;">
-        <input type="text" name="b_8b4656bd4a093a3bcabfda08a_4f80c66e83" tabindex="-1" value="">
-      </div>
-      </form>
-    </div>
-    <div class="col-xs-12 col-sm-4 col-md-4 col-lg-3">
-    </div>
-  </div><hr />
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-      <div class="page-header text-center">
-        <h3>
-          Code For Charlotte In Action
-        </h3>
-      </div>
-    </div>
-    <div class="col-sm-4 col-md-4 col-lg-4 col-xs-12">
-      <img class="img-responsive img-rounded" src="images/one.jpg" alt="" />
-
-      <p class="text-center custom-paragr lead">
-      The Charlotte fellows conferring with <strong>Councilman Greg Phipps</strong>.  Code for Charlotte
-      has ignited conversations across all levels of city and county government.
-      </p>
-    </div>
-    <div class="col-sm-4 col-md-4 col-lg-4  col-xs-12">
-      <img class="img-responsive img-rounded" src="images/two.jpg" alt="" />
-      <p class="text-center custom-paragr lead">
-      <strong>Twyla McDermott</strong> from the City's Innovation &amp; Technology department, has
-      been Code for Charlotte's primary contact inside City government.  Thanks, Twyla!
-      </p>
-    </div>
-    <div class="col-sm-4 col-md-4 col-lg-4 col-xs-12">
-      <img class="img-responsive img-rounded" src="images/three.jpg" alt="" />
-      <p class="text-center custom-paragr lead">
-      Code For Charlotte has many opportunities to get engaged in person.  Check
-      <a href="http://www.meetup.com/Code-For-Charlotte">our Meetup</a> for more
-      information.
-      </p>
-    </div>
-  </div>
-</div>
-
-

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<!-- saved from url http://www.bootstraptor.com##########################################################################
+<!-- saved from url http://www.bootstraptor.com
+##########################################################################
 Don't remove this attribution!
 This template build on Bootstrap 3 Developer  Kit v.3.0. by @Bootstraptor
 Built with Bootstrap 3.0.* version/ part of Bootstraptor KIT
@@ -7,29 +8,23 @@ Read usage license on for this template on http://www.bootstraptor.com
 ##########################################################################
 -->
 <html lang="en">
-	<head>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta charset="utf-8">
-    <title><%= current_page.data.title || "Code For Charlotte" %></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="">
-    <meta name="author" content="">
-
-    <%= partial "partials/header" %>
-
-  <body>
-<div class="wrap">
-  <%= partial "partials/nav" %>
-  <section>
-    <%= yield %>
-	</section>
-	<section class="custom-footer">
-    <%= partial "partials/footer" %>
-	</section>
-</div>
-
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="<%= current_page.data.description %>">
+  <meta name="keywords" content="<%= current_page.data.keywords %>">
+  <meta name="author" content="<%= current_page.data.author %>">
+  <title><%= current_page.data.title || "Code For Charlotte" %></title>
+<%= partial "partials/header" %>
+<body>
+<%= partial "partials/facebook" %>
+  <div class="wrap">
+<%= partial "partials/nav" %>
+<%= yield_content :jumbotron %>
+<%= yield %>
+<%= partial "partials/footer" %>
+  </div>
 <%= partial "partials/javascripts" %>
-
-
 </body>
 </html>

--- a/source/layouts/page.erb
+++ b/source/layouts/page.erb
@@ -1,0 +1,14 @@
+<% wrap_layout :layout do %>
+  <section class="features-section">
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12 col-sm-8">
+<%= yield %>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+<%= yield_content :sidebar %>
+        </div>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/source/new-members.html.erb
+++ b/source/new-members.html.erb
@@ -1,67 +1,52 @@
 ---
-title: 
+title: New Members | Code for Charlotte
+description:
+keywords:
+author:
+layout: page
 ---
-
-<div class="jumbotron">
-  <div class="container">
-    <div class="row">
-      <div class="text-left col-xs-12 col-sm-12 col-md-12 col-lg-12">
-        <h1>
-          New Members
-        </h1> <span class="second-sm">Welcome!</span>
-      </div>
-
-    </div>
-
-  </div>
-</div>
-  </section>
-  <section class="features-section">
-<div class="container">
-  <div class="row">
-    <div class="col-xs-12 col-sm-8 col-md-8 col-lg-8">
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Welcome!
-          </h3>
-        </div>
-        <div class="panel-body">
-          <p>
-          In the sidebar, you'll find a list of the things we'd like new brigade members to do.  They are all important!
-          </p>
-          <p>Meetup will keep you up to date on when we have events that you can 
-          register for.  The forum is where all brigade members can discuss items 
-          of importance.  The mailing list will include timely updates regarding 
-          the progress we're making.  Our Localwiki represents one of our 
-          major contributions to the citizens.</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-sm-4 col-md-4 col-lg-4 col-xs-12">
-
-      <div class="panel panel-default custom-panel">
-        <div class="panel-heading">
-          <h3>
-            Quick Checklist
-          </h3>
-        </div>
-        <div class="panel-body">
-          <p>
-          <ul>
-            <li>Sign up for <a href="http://www.meetup.com/Code-For-Charlotte">Meetup</a>.</li>
-            <li>Register for the <a href="http://forum.codeforcharlotte.org/">Forum</a>.</li>
-            <li><a href="http://forum.codeforcharlotte.org/t/introductions-brigade-members/148">Introduce yourself</a>.</li>
-            <li>Sign up for the <a href="http://eepurl.com/QKgqr">Mailing List</a>.</li>
-            <li>Contribute to the <a href="http://www.localwiki.net/charlotte/">LocalWiki</a></li>
-            <li>Find a project [coming soon]</li>
-          </ul>
-
-          </p>
-        </div>
-      </div>
-
-    </div>
-  </div><hr />
-</div>
+<% content_for :jumbotron do %>
+<%= partial(:'partials/jumbotron', :locals => {:headline => 'New Members', :subheadline => 'Welcome' }) %>
+<% end %>
+          <div class="panel panel-default custom-panel">
+            <div class="panel-heading">
+              <h3>
+                Welcome!
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p>
+                Below you'll find a list of the things we'd like new brigade members to do.  They are all important!
+              </p>
+              <p>
+                Meetup will keep you up to date on when we have events that you can
+                register for.  The forum is where all brigade members can discuss items
+                of importance.  The mailing list will include timely updates regarding
+                the progress we're making.  Our Localwiki represents one of our
+                major contributions to the citizens.
+              </p>
+            </div>
+          </div>
+          <hr />
+          <div class="panel panel-default custom-panel">
+            <div class="panel-heading">
+              <h3>
+                Quick Checklist
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p>
+                <ul>
+                  <li>Sign up for <%= link_to 'Meetup', 'http://www.meetup.com/Code-For-Charlotte' %>.</li>
+                  <li>Register for the <%= link_to 'Forum', 'http://forum.codeforcharlotte.org/' %>.</li>
+                  <li><%= link_to 'Introduce Yourself', 'http://forum.codeforcharlotte.org/t/introductions-brigade-members/148' %>.</li>
+                  <li>Sign up for the <%= link_to 'Mailing List', 'http://eepurl.com/QKgqr' %>.</li>
+                  <li>Contribute to the <%= link_to 'LocalWiki', 'http://www.localwiki.net/charlotte/' %></li>
+                  <li>Find a project [coming soon]</li>
+                </ul>
+              </p>
+            </div>
+          </div>
+<% content_for :sidebar do %>
+<%= partial(:'partials/sidebar') %>
+<% end %>

--- a/source/partials/_facebook.erb
+++ b/source/partials/_facebook.erb
@@ -1,0 +1,11 @@
+  <!-- FB JavaScript SDK -->
+  <div id="fb-root"></div>
+  <script>
+    (function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s); js.id = id;
+      js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&appId=253729824819470&version=v2.0";
+      fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));
+  </script>

--- a/source/partials/_jumbotron.erb
+++ b/source/partials/_jumbotron.erb
@@ -1,0 +1,14 @@
+  <section>
+    <div class="jumbotron">
+      <div class="container">
+        <div class="row">
+          <div class="text-left col-xs-12">
+            <h1>
+              <%= headline %>
+            </h1>
+            <span class="second-sm"><%= subheadline %></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>

--- a/source/partials/_sidebar.erb
+++ b/source/partials/_sidebar.erb
@@ -1,0 +1,3 @@
+          <div class="fb-like-box" data-href="https://www.facebook.com/codeforcharlotte" data-colorscheme="dark" data-show-faces="true" data-header="false" data-stream="false" data-show-border="false"></div>
+          <a class="twitter-timeline" href="https://twitter.com/CodeForCLT" data-widget-id="475414430839087104">Tweets by @CodeForCLT</a>
+          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -1,23 +1,14 @@
 ---
-title:
+title: Team | Code for Charlotte
+description:
+keywords:
+author:
+layout: page
 ---
-
-<div class="jumbotron">
-      <div class="container">
-        <div class="row">
-          <div class="text-left col-xs-12 col-sm-12 col-md-12 col-lg-12">
-            <h1>Team</h1>
-            <span class="second-sm">Thank You!</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-  <section class="features-section">
-    <div class="container">
-      <div class="row">
-        <div class="col-sm-12 col-md-12 col-lg-12 col-xs-12">
-          <% data.team.each do | t | %>
+<% content_for :jumbotron do %>
+<%= partial(:'partials/jumbotron', :locals => {:headline => 'Team', :subheadline => 'Thank You!' }) %>
+<% end %>
+<% data.team.each do | t | %>
           <div class="panel panel-default custom-panel">
             <div class="panel-heading">
               <h3><%= t['type'].capitalize %></h3>
@@ -26,7 +17,7 @@ title:
             <% unless t['person'].empty? %>
               <% t['person'].each do |p| %>
               <div class="col-sm-6 panel-body">
-                <%= image_tag "http://www.gravatar.com/avatar/"+Digest::MD5.hexdigest(p['email'].downcase)+".jpg?s=200&r=g&d=mm", :width => '200',
+                <%= image_tag 'http://www.gravatar.com/avatar/'+Digest::MD5.hexdigest(p['email'].downcase)+'.jpg?s=200&r=g&d=mm', :width => '200',
            :class => 'img-responsive img-circle pull-left img-team' %>
                 <h4><%= p['name'] %></h4>
                 <%= p['bio'] %>
@@ -35,8 +26,7 @@ title:
             <% end %>
             </div>
           </div>
-          <% end %>
-        </div>
-      </div>
-      <hr />
-    </div>
+<% end %>
+<% content_for :sidebar do %>
+<%= partial(:'partials/sidebar') %>
+<% end %>


### PR DESCRIPTION
... area for primary content and a 4 column right area for sidebar content via yield_content.

Previously all pages redundantly declared their own Jumbotron. The jumbotron markup has been moved into a partial that accepts parameters and the jumbotron is now called thru yield_content. This allows a template to be as custom as it would like such as the homepage, or standardized like all other pages thru the jumbotron partial & parameters. As Jumbotrons were commmon to all pages this yield_content call is in the global layout.erb. Not all pages (such as the homepage) will need sidebar content so page is a nested layout. The nested layout page has a yield_content for sidebar content so that additional content or in place of the sidebar default social media content from Facebook & Twitter can be used.

A partial was added for the Facebook specific JavaScript SDK calls that need to be inserted after the body tag and the calling js function was added to the new partial sidebar.erb. Twitter's respective content is also added to sidebar.erb.

The pages about-us, team, new-members were all updated to use the new page nested layout, the homepage was updated to use the new layout
