### PR TITLE
Creates a partners page, addressing Issue #24

### DIFF
--- a/data/partners.yml
+++ b/data/partners.yml
@@ -1,0 +1,6 @@
+---
+-
+  name: Fictitious Organization
+  url: http://fictitious.org
+  description: Fictitious is an exemplorary organization of doing wonderful things
+  motivation: By working with Code for Charlotte Fictitious seeks to further the cause of being fictitious.

--- a/source/partners.html.erb
+++ b/source/partners.html.erb
@@ -1,0 +1,35 @@
+---
+title: Partners | Code for Charlotte
+description:
+keywords:
+author:
+layout: page
+---
+<% content_for :jumbotron do %>
+<%= partial(:'partials/jumbotron', :locals => {:headline => 'Partners', :subheadline => 'Joined with Code for Charlotte' }) %>
+<% end %>
+            <div class="panel panel-default custom-panel">
+              <div class="panel-heading">
+                <h3>Partners</h3>
+              </div>
+              <div class="row">
+                <% data.partners.each do | p | %>
+                <div class="col-sm-6">
+                  <div class="panel-body">
+                    <h4 class="text-center">
+                      <%= link_to p['name'], p['url'] %>
+                    </h4>
+                    <h4>
+                      <small>
+                        <%= p['description'] %>
+                      </small>
+                    </h4>
+                    <%= p['motivation'] %>
+                  </div>
+                </div>
+                <% end %>
+              </div>
+            </div>
+<% content_for :sidebar do %>
+<%= partial(:'partials/sidebar') %>
+<% end %>


### PR DESCRIPTION
Essentially a clone of the team page, adds a data/partners.yml with the data fields requested in the issue. Without sample data the layout in the page is just a guess wrapping the partner's URL around the name of the organization, using a bootrap heading small class for the description of the organization and just printing out the organization's motivation for working with Code for Charlotte. All the panel bodies are set to be column 6 in one giant row so they'll just auto wrap around if there is an even or odd number of partners and bypass the need to do row/column counting.
