### PR TITLE
Replaces Google Universal Analytics code in partials/_javascripts.erb wi...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "middleman", "~>3.3.2"
 gem "middleman-livereload", "~> 3.2.1"
 
 gem 'middleman-gh-pages'
+gem "middleman-google-analytics"
 gem 'rake'
 gem "middleman-blog"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,9 @@ GEM
       tilt (~> 1.4.1, < 2.0)
     middleman-gh-pages (0.0.3)
       rake (> 0.9.3)
+    middleman-google-analytics (1.0.2)
+      middleman-core (~> 3.2)
+      uglifier (>= 2.1, < 3.0)
     middleman-livereload (3.2.1)
       em-websocket (~> 0.5.0)
       middleman-core (~> 3.2)
@@ -126,6 +129,7 @@ DEPENDENCIES
   middleman (~> 3.3.2)
   middleman-blog
   middleman-gh-pages
+  middleman-google-analytics
   middleman-livereload (~> 3.2.1)
   rake
   ruby18_source_location

--- a/config.rb
+++ b/config.rb
@@ -51,6 +51,24 @@ set :js_dir, 'javascripts'
 
 set :images_dir, 'images'
 
+# Google Analytics
+activate :google_analytics do |ga|
+  # Property ID (default = nil)
+  ga.tracking_id = 'UA-51227922-3'
+  # Removing the last octet of the IP address (default = false)
+  ga.anonymize_ip = false
+  # Tracking across a domain and its subdomains (default = nil)
+  ga.domain_name = 'codeforcharlotte.org'
+  # Tracking across multiple domains and subdomains (default = false)
+  ga.allow_linker = false
+  # Tracking Code Debugger (default = false)
+  ga.debug = false
+  # Tracking in development environment (default = true)
+  ga.development = false
+  # Compress the JavaScript code (default = false)
+  ga.minify = true
+end
+
 # Build-specific configuration
 configure :build do
   # For example, change the Compass output style for deployment
@@ -67,7 +85,7 @@ configure :build do
   activate :blog do |blog|
   # set options on blog
 end
-  
+
 
   # Or use a different image path
   # set :http_prefix, "/Content/images/"

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -25,6 +25,7 @@ Read usage license on for this template on http://www.bootstraptor.com
 <%= yield %>
 <%= partial "partials/footer" %>
   </div>
-<%= partial "partials/javascripts" %>
+  <%= partial "partials/javascripts" %>
+  <%= google_analytics_universal_tag %>
 </body>
 </html>

--- a/source/partials/_javascripts.erb
+++ b/source/partials/_javascripts.erb
@@ -1,12 +1,2 @@
 <%= javascript_include_tag "jquery" %>
 <%= javascript_include_tag "bootstrap" %>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-51227922-3', 'codeforcharlotte.org');
-  ga('send', 'pageview');
-
-</script>


### PR DESCRIPTION
...th the middleman extension middleman-google-analytics. Fixes issue #20

The advantage of making the change is that the extension has a setting for not displaying the analytics code during development so while I'm working on features I'm not driving up pageviews. The change requires adding the extension to the Gemfile, running 'bundle install' so Gemfile.lock gets updated, and adding the relevant call to our layout.erb after the footer. Easy Peasy
