### PR TITLE
Adds a helper function that extends padrino's link_to to check if the cu...

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -39,11 +39,17 @@
 # activate :livereload
 
 # Methods defined in the helpers block are available in templates
-# helpers do
-#   def some_helper
-#     "Helping"
-#   end
-# end
+  helpers do
+    def nav_link_to(link, url, opts={})
+      if current_resource.url == url_for(url)
+        prefix = '<li class="active">'
+      else
+        prefix = '<li>'
+      end
+      prefix + link_to(link, url, opts) + "</li>"
+    end
+  end
+
 
 set :css_dir, 'stylesheets'
 


### PR DESCRIPTION
...rrent page URL matches the URL in the navigation and add the twitter active class

This was such an easy fix that has vexed me. I knew there had to be some way to do this but I hadn't really understand the right way within the middleman process to figure where to do this myself.
I got lucky and found https://github.com/middleman/middleman/issues/303#issuecomment-4362124
