### PR TITLE
Rearranges the navigation and uses the previously added nav_link_to help...

### DIFF
--- a/source/partials/_nav.erb
+++ b/source/partials/_nav.erb
@@ -8,12 +8,21 @@
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="#">Code For Charlotte</a>
+            <%= link_to 'Code for Charlotte', '/', {:class => 'navbar-brand'} %>
           </div>
           <div class="collapse navbar-collapse navbar-ex1-collapse">
             <ul class="nav navbar-nav">
-              <li class="active">
-                <%= link_to 'Home', '/' %>
+              <%= nav_link_to 'Home', '/' %>
+              <li class="dropdown">
+                <%= link_to 'About <span class="caret"></span>', '/about.html', {:class => 'dropdown-toggle', :data => {:toggle => 'dropdown'}} %>
+                <ul class="dropdown-menu">
+                  <li><%= link_to 'Mission', '/about.html' %></li>
+                  <li><%= link_to 'Partners', '/partners.html' %></li>
+                  <li><%= link_to 'Team', '/team.html' %></li>
+                </ul>
+              </li>
+              <li>
+                <%= nav_link_to 'New Members', '/new-members.html' %>
               </li>
               <li>
                 <%= link_to 'Forum', 'http://forum.codeforcharlotte.org' %>


### PR DESCRIPTION
...er so that pages in the navigation will properly use the bootstrap active class

Collapsed a number of related but seperate pages into a dropdown menu called about. The renamed about-us to about that has information primarly on the when & why the Code for Charlotte brigade was formed and it's mission, the captains/team member listing was a small panel on the about-us page, and the recenly added partners page. All of these are topics somone would want to know 'about'

Since another target is to increase the breadth and depth of new members, I moved the instructions for new members 'new-members.html' from the footer up to the navigation.

Finally 'Home' & 'New Members' make use of the helper nav_link_to helper so that when you click on those pages and only those pages will those list items be highlighted by bootstrap to indicate the current page. I did use the helper on the other navigation links because they're all links away from the site.
