### PR TITLE
Fixes a problem where email addresses that were null were causing the pa...

### DIFF
--- a/source/partials/_team.erb
+++ b/source/partials/_team.erb
@@ -1,0 +1,6 @@
+              <div class="col-sm-6 panel-body text-right">
+                <%= image_tag 'http://www.gravatar.com/avatar/'+Digest::MD5.hexdigest(email.downcase)+'.jpg?s=200&r=g&d=mm', :width => '200',
+                    :class => 'img-responsive img-circle pull-left img-team' unless (email.blank?) %>
+                <h4><%= name %></h4>
+                <%= bio %>
+              </div>

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -15,13 +15,10 @@ layout: page
             </div>
             <div class="row">
             <% unless t['person'].empty? %>
-              <% t['person'].each do |p| %>
-              <div class="col-sm-6 panel-body">
-                <%= image_tag 'http://www.gravatar.com/avatar/'+Digest::MD5.hexdigest(p['email'].downcase)+'.jpg?s=200&r=g&d=mm', :width => '200',
-           :class => 'img-responsive img-circle pull-left img-team' %>
-                <h4><%= p['name'] %></h4>
-                <%= p['bio'] %>
-              </div>
+              <% has_no_email, has_email = t['person'].partition { | person | person['email'].blank? } %>
+              <% team_sorted_by_email_first = has_email.concat has_no_email %>
+              <% team_sorted_by_email_first.each do | s |  %>
+<%= partial(:'partials/team', :locals => {:name => s['name'], :email =>s['email'], :bio => s['bio'] }) %>
               <% end %>
             <% end %>
             </div>


### PR DESCRIPTION
...ge build to fail. Also corrects layout errors caused when no email address was present

I wasn't checking that email.blank? before handing the email to the md5 of gravatar generation. So I had to check for both nil and empty strings. Once I had some users who preferred not to add an email address and rolled through the whole array I found that layouts were janky. Specifically 6 column entries with no image didn't take the full 6 columns so they'd collapse and the effect was a jumble of names than nice columns of team members. Now the team members are sorted by email address first, so they are printed in nice 6 column fields then fill in with everybody else. If that looks terrible as more team members add themselves we'll fix it then.
