### PR TITLE
Adds Logical Advantage as a partner

### DIFF
--- a/data/partners.yml
+++ b/data/partners.yml
@@ -9,3 +9,8 @@
   url: http://www.queens.edu/Academics-and-Schools/Schools-and-Colleges/Knight-School-of-Communication.html
   description: The mission of the James L. Knight School of Communication is to prepare consumers and creators of communication messages to become engaged citizens, advocates and leaders in the communities they serve. In our academic programs and our community initiatives, we are discovering how universities can shape their local media ecosystems.
   motivation: Dean Eric Freedman has welcomed us to his lab in the name of citizen engagement and many other items.  Be sure to check out Digital Charlotte.
+-
+  name: Logical Advantage
+  url: http://www.logicaladvantage.com
+  description: Logical Advantage provides a variety of solutions to support business IT, including Application Outsourcing, IT Consulting and IT Staffing.
+  motivation: LA is a proud supporter of Code for Charlotte. Not only for its purpose, but to also advance the visibility of the technology committee within the great Charlotte area.


### PR DESCRIPTION
The description of LA was taken straight from the meta description field from their homepage because a description was not provided in the request email.
