### PR TITLE
Links in instructions list open in a new tab

### DIFF
--- a/source/new-members.html.erb
+++ b/source/new-members.html.erb
@@ -36,12 +36,12 @@ layout: page
               <div class="panel-body">
                 <p>
                   <ul class="instructions-list">
-                    <li>Sign up for <%= link_to 'Meetup', 'http://www.meetup.com/Code-For-Charlotte' %>.</li>
-                    <li>Register for the <%= link_to 'Forum', 'http://forum.codeforcharlotte.org/' %>.</li>
-                    <li>Sign up for <%= link_to 'Slack', 'https://codeforclt.typeform.com/to/wcYsrE' %> </li>
-                    <li><%= link_to 'Add Yourself to the Website', 'add-yourself-to-website.html' %>.</li>
-                    <li>Sign up for the <%= link_to 'Mailing List', 'http://eepurl.com/QKgqr' %>.</li>
-                    <li>Contribute to the <%= link_to 'LocalWiki', 'http://www.localwiki.net/charlotte/' %></li>
+                    <li>Sign up for <%= link_to 'Meetup', 'http://www.meetup.com/Code-For-Charlotte', :target => '_blank' %>.</li>
+                    <li>Register for the <%= link_to 'Forum', 'http://forum.codeforcharlotte.org/', :target => '_blank' %>.</li>
+                    <li>Sign up for <%= link_to 'Slack', 'https://codeforclt.typeform.com/to/wcYsrE', :target => '_blank' %> </li>
+                    <li><%= link_to 'Add Yourself to the Website', 'add-yourself-to-website.html', :target => '_blank' %>.</li>
+                    <li>Sign up for the <%= link_to 'Mailing List', 'http://eepurl.com/QKgqr', :target => '_blank' %>.</li>
+                    <li>Contribute to the <%= link_to 'LocalWiki', 'http://www.localwiki.net/charlotte/', :target => '_blank' %></li>
                     <li>Find a project [coming soon]</li>
                   </ul>
                 </p>


### PR DESCRIPTION
Right now the instructions for new users send them out to a new site when clicked, which means they're likely to lose their place in the list, or lose the site altogether.  This should provide a better user experience.